### PR TITLE
Action fails due to no -i flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ try {
   console.log(`  i: ${input}`);
   console.log(`  o: ${output}`);
 
-  let command = `cyclonedx-py -i ${input} -o ${output}`
+  let command = `cyclonedx-py -r -o ${output}`
 
   console.log(`Running: ${command}`);
 


### PR DESCRIPTION
If used as per the instructions, 

![cyclonedx_ga](https://user-images.githubusercontent.com/7882621/137934587-55cb00ff-1d9a-4646-8c50-84fe14b31173.png)


the build will fail to there being no -i flag in cyclonedx-py. 


![cyclonedx_ga_fail](https://user-images.githubusercontent.com/7882621/137934631-474b9eab-d969-42a3-8e99-d90b8524abdc.png)


The fix is to use the -r, which looks for requirements.txt by default and should run ok. 